### PR TITLE
Added an option to throw an exception when a connect fails instead of ex...

### DIFF
--- a/src/main/java/com/github/theholywaffle/teamspeak3/TS3Query.java
+++ b/src/main/java/com/github/theholywaffle/teamspeak3/TS3Query.java
@@ -4,7 +4,7 @@
  * are made available under the terms of the GNU Public License v3.0
  * which accompanies this distribution, and is available at
  * http://www.gnu.org/licenses/gpl.html
- * 
+ *
  * Contributors:
  *     Bert De Geyter (https://github.com/TheHolyWaffle) - initial API and implementation
  ******************************************************************************/
@@ -21,6 +21,8 @@ import java.util.logging.Logger;
 
 import com.github.theholywaffle.teamspeak3.api.Callback;
 import com.github.theholywaffle.teamspeak3.commands.Command;
+import com.github.theholywaffle.teamspeak3.api.exception.TS3CommandFailedException;
+import com.github.theholywaffle.teamspeak3.api.exception.TS3ConnectFailedException;
 import com.github.theholywaffle.teamspeak3.log.LogHandler;
 
 public class TS3Query {
@@ -41,6 +43,9 @@ public class TS3Query {
 
 	private int floodRate;
 	private TS3Api bot;
+
+    private boolean exitOnConnectFailure = true;
+    private boolean throwExceptionWhenCommandFails;
 
 	public static final Logger log = Logger.getLogger(TS3Query.class.getName());
 
@@ -102,7 +107,11 @@ public class TS3Query {
 
 		} catch (IOException e) {
 			e.printStackTrace();
-			System.exit(1);
+            if(exitOnConnectFailure) {
+			    System.exit(1);
+            } else {
+                throw new TS3ConnectFailedException("An error occurred while connecting with teamspeak", e);
+            }
 		}
 		return this;
 	}
@@ -126,6 +135,9 @@ public class TS3Query {
 			try {
 				Thread.sleep(50);
 			} catch (InterruptedException e) {
+                if(throwExceptionWhenCommandFails) {
+                    throw new TS3CommandFailedException("An error occurred while sending a command to a teamspeak server", e);
+                }
 				e.printStackTrace();
 			}
 		}
@@ -198,4 +210,11 @@ public class TS3Query {
 		return bot;
 	}
 
+    public void setExitOnConnectFailure(boolean exitOnConnectFailure) {
+        this.exitOnConnectFailure = exitOnConnectFailure;
+    }
+
+    public void setThrowExceptionWhenCommandFails(boolean throwExceptionWhenCommandFails) {
+        this.throwExceptionWhenCommandFails = throwExceptionWhenCommandFails;
+    }
 }

--- a/src/main/java/com/github/theholywaffle/teamspeak3/api/exception/TS3CommandFailedException.java
+++ b/src/main/java/com/github/theholywaffle/teamspeak3/api/exception/TS3CommandFailedException.java
@@ -1,0 +1,11 @@
+package com.github.theholywaffle.teamspeak3.api.exception;
+
+public class TS3CommandFailedException extends TS3Exception {
+    public TS3CommandFailedException(String message) {
+        super(message);
+    }
+
+    public TS3CommandFailedException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/src/main/java/com/github/theholywaffle/teamspeak3/api/exception/TS3ConnectFailedException.java
+++ b/src/main/java/com/github/theholywaffle/teamspeak3/api/exception/TS3ConnectFailedException.java
@@ -1,0 +1,11 @@
+package com.github.theholywaffle.teamspeak3.api.exception;
+
+public class TS3ConnectFailedException extends TS3Exception {
+    public TS3ConnectFailedException(String message) {
+        super(message);
+    }
+
+    public TS3ConnectFailedException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/src/main/java/com/github/theholywaffle/teamspeak3/api/exception/TS3Exception.java
+++ b/src/main/java/com/github/theholywaffle/teamspeak3/api/exception/TS3Exception.java
@@ -18,4 +18,7 @@ public class TS3Exception extends RuntimeException {
 		super(msg + " [Please report this exception to the developer!]");
 	}
 
+    public TS3Exception(String msg, Throwable cause) {
+        super(msg, cause);
+    }
 }


### PR DESCRIPTION
...itting the jvm using System.exit()

It is incredibly annoying when creating a webapp that handles multiple teamspeak connections that the entire JVM exits if 1 server goes down. I've made the option configurable, but to be honest, System.exit [rarely makes sense](http://www.javapractices.com/topic/TopicAction.do?Id=86).
