### PR TITLE
Update sshj version from 0.31.0 to 0.32.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -57,7 +57,7 @@
 		<dependency>
 			<groupId>com.hierynomus</groupId>
 			<artifactId>sshj</artifactId>
-			<version>0.31.0</version>
+			<version>0.32.0</version>
 		</dependency>
 		<dependency>
 			<groupId>org.slf4j</groupId>


### PR DESCRIPTION
Currently, when trying to run a project with this dependency on the module path, you will get the following exception:
`Error occurred during initialization of boot layer
java.lang.module.FindException: Unable to derive module descriptor for C:\Users\<user>\.m2\repository\com\hierynomus\asn-one\0.5.0\asn-one-0.5.0.jar
Caused by: java.lang.module.FindException: Automatic-Module-Name: com.hierynomus.asn-one: Invalid module name: 'asn-one' is not a Java identifier`

This due to a dependency of sshj having an invalid automatic module name.
To fix this, this pull request updates sshj to 0.32.0, which uses  an updated version of the problematic dependency, which no longer has this problem.

I'm not familiar with this projects code base and how it uses sshj, but from looking at the changelog of the newer version, there shouldn't be any breaking changes.