### PR TITLE
Update PermissionCommands.java

### DIFF
--- a/src/main/java/com/github/theholywaffle/teamspeak3/commands/PermissionCommands.java
+++ b/src/main/java/com/github/theholywaffle/teamspeak3/commands/PermissionCommands.java
@@ -145,7 +145,7 @@ public final class PermissionCommands {
 	 * Channel commands
 	 */
 
-	public static Command channelAddPerm(int channelId, String permName, int permValue) {
+	public static Command channelAddPerm(int channelId, String permName, long permValue) {
 		nonEmptyPermissionName(permName);
 
 		CommandBuilder builder = new CommandBuilder("channeladdperm", 3);


### PR DESCRIPTION
This pull request updates the method signature of channelAddPerm to use long instead of int for the permValue parameter. The change was made because permValue (e.g., channelIconId) can exceed the maximum value of an int.